### PR TITLE
Fuyou

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,5 +102,5 @@ subprojects {
 
 //执行gradle wrapper自动生成gradlew脚本及配置
 task wrapper(type: Wrapper) {
-    gradleVersion = '4.0.1'
+    gradleVersion = '4.10.2'
 }

--- a/frame/src/main/java/com/appengine/auth/annotation/RateLimitType.java
+++ b/frame/src/main/java/com/appengine/auth/annotation/RateLimitType.java
@@ -12,7 +12,9 @@ import java.util.Map;
  */
 public enum RateLimitType {
     IP(AuthExcepFactor.E_IP_RATE_LIMIT),
+    IPMETHOD(AuthExcepFactor.E_IP_RATE_LIMIT),
     USER(AuthExcepFactor.E_USER_RATE_LIMIT),
+    USERMETHOD(AuthExcepFactor.E_USER_RATE_LIMIT),
     PARAM(AuthExcepFactor.E_API_RATE_LIMIT);
 
     ExcepFactor excepFactor;
@@ -29,8 +31,12 @@ public enum RateLimitType {
         switch (this) {
             case IP:
                 return "i_" + rc.getIp();
+            case IPMETHOD:
+                return "i_" + rc.getOriginRequest().getRequestURI() + rc.getIp();
             case USER:
                 return "u_" + rc.getCurrentUid();
+            case USERMETHOD:
+                return "u_" + rc.getOriginRequest().getRequestURI() + rc.getCurrentUid();
             case PARAM:
                 return "p_" + getRequestParamString(rc.getOriginRequest().getParameterMap());
             default:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 26 16:25:02 CST 2017
+#Mon Jan 21 10:37:22 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
升级 gradle 版本到 4.10.2 为升级 5.0 以上做准备
添加接口频率限制类型，支持更细粒度的频率限制